### PR TITLE
Myriad.ecs

### DIFF
--- a/src/ECS.Benchmark.csproj
+++ b/src/ECS.Benchmark.csproj
@@ -17,6 +17,7 @@
       <PackageReference Include="DefaultEcs.Analyzer" Version="0.17.0" PrivateAssets="all" />
       <PackageReference Include="fennecs" Version="0.5.9-beta" />
       <PackageReference Include="Friflo.Engine.ECS" Version="3.0.0-preview.4" />
+      <PackageReference Include="Myriad.ECS" Version="21.0.0" />
       <PackageReference Include="Scellecs.Morpeh" Version="2023.1.0" />
       <PackageReference Include="TinyEcs.Main" Version="1.4.0" />
       <PackageReference Include="Leopotam.EcsLite" Version="1.0.1" />

--- a/src/Myriad/CommandBufferAddRemoveT2.cs
+++ b/src/Myriad/CommandBufferAddRemoveT2.cs
@@ -18,16 +18,10 @@ public class CommandBufferAddRemoveT2_Myriad
     {
         world = new WorldBuilder().Build();
 
-        // Create all the entities using a command buffer
-        cmd = new CommandBuffer(world);
-        for (var i = 0; i < Constants.EntityCount; i++)
-            cmd.Create();
-        using var resolver = cmd.Playback();
+        entities = world.CreateEntities(Constants.EntityCount);
+        entities.AddComponents(world);
 
-        // Extract the created entities
-        entities = new Entity[Constants.EntityCount];
-        for (var i = 0; i < resolver.Count; i++)
-            entities[i] = resolver[i];
+        cmd = new CommandBuffer(world);
     }
 
     [GlobalCleanup]

--- a/src/Myriad/CommandBufferAddRemoveT2.cs
+++ b/src/Myriad/CommandBufferAddRemoveT2.cs
@@ -1,0 +1,56 @@
+using BenchmarkDotNet.Attributes;
+using Myriad.ECS;
+using Myriad.ECS.Command;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+[BenchmarkCategory(Category.CommandBufferAddRemoveT2)]
+// ReSharper disable once InconsistentNaming
+public class CommandBufferAddRemoveT2_Myriad
+{
+    private World world;
+    private Entity[] entities;
+    private CommandBuffer cmd;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new WorldBuilder().Build();
+
+        // Create all the entities using a command buffer
+        cmd = new CommandBuffer(world);
+        for (var i = 0; i < Constants.EntityCount; i++)
+            cmd.Create();
+        using var resolver = cmd.Playback();
+
+        // Extract the created entities
+        entities = new Entity[Constants.EntityCount];
+        for (var i = 0; i < resolver.Count; i++)
+            entities[i] = resolver[i];
+    }
+
+    [GlobalCleanup]
+    public void Shutdown()
+    {
+        world.Dispose();
+    }
+    
+    [Benchmark]
+    public void Run()
+    {
+        foreach (var entity in entities)
+        {
+            cmd.Set(entity, new Component1());
+            cmd.Set(entity, new Component2());
+        }
+        cmd.Playback().Dispose();
+        
+        foreach (var entity in entities)
+        {
+            cmd.Remove<Component1>(entity);
+            cmd.Remove<Component2>(entity);
+        }
+        cmd.Playback().Dispose();
+    }
+}

--- a/src/Myriad/CreateWorld.cs
+++ b/src/Myriad/CreateWorld.cs
@@ -1,0 +1,16 @@
+using BenchmarkDotNet.Attributes;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+[BenchmarkCategory(Category.CreateWorld)]
+// ReSharper disable once InconsistentNaming
+public class CreateWorld_Myriad
+{
+    [Benchmark]
+    public void Run()
+    {
+        var world = new WorldBuilder().Build();
+        world.Dispose();
+    }
+}

--- a/src/Myriad/QueryFragmentedT1.cs
+++ b/src/Myriad/QueryFragmentedT1.cs
@@ -1,0 +1,62 @@
+using BenchmarkDotNet.Attributes;
+using Myriad.ECS;
+using Myriad.ECS.Command;
+using Myriad.ECS.Queries;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+[BenchmarkCategory(Category.QueryFragmentedT1)]
+// ReSharper disable once InconsistentNaming
+public class QueryFragmentedT1_Myriad
+{
+    private World world;
+    private QueryDescription query;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new WorldBuilder().Build();
+
+        // Create all the entities using a command buffer
+        var cmd = new CommandBuffer(world);
+        for (var i = 0; i < Constants.EntityCount; i++)
+        {
+            var entity = cmd.Create();
+
+            entity.Set(new Component1());
+
+            if ((i & 1) != 0) entity.Set<Component2>(default);
+            if ((i & 2) != 0) entity.Set<Component3>(default);
+            if ((i & 4) != 0) entity.Set<Component4>(default);
+            if ((i & 8) != 0) entity.Set<Component5>(default);
+        }
+
+        cmd.Playback().Dispose();
+
+        query = new QueryBuilder().Include<Component1>().Build(world);
+        if (query.Count() != Constants.EntityCount)
+            throw new Exception("Setup failed to create correct number of entities (Myriad bug?)");
+    }
+
+    [GlobalCleanup]
+    public void Shutdown()
+    {
+        world.Dispose();
+    }
+
+    [Benchmark]
+    public void Run()
+    {
+        world.Execute<IncrementComponent1, Component1>(query);
+    }
+
+    private readonly struct IncrementComponent1
+        : IQuery1<Component1>
+    {
+        public void Execute(Entity e, ref Component1 t0)
+        {
+            t0.Value++;
+        }
+    }
+}

--- a/src/Myriad/QueryFragmentedT1.cs
+++ b/src/Myriad/QueryFragmentedT1.cs
@@ -20,7 +20,7 @@ public class QueryFragmentedT1_Myriad
 
         // Create all the entities using a command buffer
         var cmd = new CommandBuffer(world);
-        for (var i = 0; i < Constants.EntityCount; i++)
+        for (var i = 0; i < Constants.FragmentationCount; i++)
         {
             var entity = cmd.Create();
 
@@ -35,7 +35,7 @@ public class QueryFragmentedT1_Myriad
         cmd.Playback().Dispose();
 
         query = new QueryBuilder().Include<Component1>().Build(world);
-        if (query.Count() != Constants.EntityCount)
+        if (query.Count() != Constants.FragmentationCount)
             throw new Exception("Setup failed to create correct number of entities (Myriad bug?)");
     }
 

--- a/src/Myriad/QueryT1.cs
+++ b/src/Myriad/QueryT1.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using Myriad.ECS;
+using Myriad.ECS.Command;
+using Myriad.ECS.Queries;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+[BenchmarkCategory(Category.QueryT1)]
+// ReSharper disable once InconsistentNaming
+public class QueryT1_Myriad
+{
+    private World world;
+    private QueryDescription query;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new WorldBuilder().Build();
+
+        // Create all the entities using a command buffer
+        var cmd = new CommandBuffer(world);
+        for (var i = 0; i < Constants.EntityCount; i++)
+            cmd.Create().Set(new Component1()).Set(new Component2()).Set(new Component3()).Set(new Component4()).Set(new Component5());
+        using var resolver = cmd.Playback();
+
+        query = new QueryBuilder().Include<Component1>().Build(world);
+        if (query.Count() != Constants.EntityCount)
+            throw new Exception("Setup failed to create correct number of entities (Myriad bug?)");
+    }
+
+    [GlobalCleanup]
+    public void Shutdown()
+    {
+        world.Dispose();
+    }
+
+    [Benchmark]
+    public void Run()
+    {
+        world.Execute<IncrementComponent1, Component1>(query);
+    }
+
+    private readonly struct IncrementComponent1
+        : IQuery1<Component1>
+    {
+        public void Execute(Entity e, ref Component1 t0)
+        {
+            t0.Value++;
+        }
+    }
+}

--- a/src/Myriad/QueryT1.cs
+++ b/src/Myriad/QueryT1.cs
@@ -18,11 +18,8 @@ public class QueryT1_Myriad
     {
         world = new WorldBuilder().Build();
 
-        // Create all the entities using a command buffer
-        var cmd = new CommandBuffer(world);
-        for (var i = 0; i < Constants.EntityCount; i++)
-            cmd.Create().Set(new Component1()).Set(new Component2()).Set(new Component3()).Set(new Component4()).Set(new Component5());
-        using var resolver = cmd.Playback();
+        var entities = world.CreateEntities(Constants.EntityCount);
+        entities.AddComponents(world);
 
         query = new QueryBuilder().Include<Component1>().Build(world);
         if (query.Count() != Constants.EntityCount)

--- a/src/Myriad/QueryT5.cs
+++ b/src/Myriad/QueryT5.cs
@@ -18,11 +18,8 @@ public class QueryT5_Myriad
     {
         world = new WorldBuilder().Build();
 
-        // Create all the entities using a command buffer
-        var cmd = new CommandBuffer(world);
-        for (var i = 0; i < Constants.EntityCount; i++)
-            cmd.Create().Set(new Component1()).Set(new Component2()).Set(new Component3()).Set(new Component4()).Set(new Component5());
-        using var resolver = cmd.Playback();
+        var entities = world.CreateEntities(Constants.EntityCount);
+        entities.AddComponents(world);
 
         query = new QueryBuilder().Include<Component1, Component2, Component3, Component4, Component5>().Build(world);
         if (query.Count() != Constants.EntityCount)

--- a/src/Myriad/QueryT5.cs
+++ b/src/Myriad/QueryT5.cs
@@ -1,0 +1,52 @@
+using BenchmarkDotNet.Attributes;
+using Myriad.ECS;
+using Myriad.ECS.Command;
+using Myriad.ECS.Queries;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+[BenchmarkCategory(Category.QueryT5)]
+// ReSharper disable once InconsistentNaming
+public class QueryT5_Myriad
+{
+    private World world;
+    private QueryDescription query;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new WorldBuilder().Build();
+
+        // Create all the entities using a command buffer
+        var cmd = new CommandBuffer(world);
+        for (var i = 0; i < Constants.EntityCount; i++)
+            cmd.Create().Set(new Component1()).Set(new Component2()).Set(new Component3()).Set(new Component4()).Set(new Component5());
+        using var resolver = cmd.Playback();
+
+        query = new QueryBuilder().Include<Component1, Component2, Component3, Component4, Component5>().Build(world);
+        if (query.Count() != Constants.EntityCount)
+            throw new Exception("Setup failed to create correct number of entities (Myriad bug?)");
+    }
+
+    [GlobalCleanup]
+    public void Shutdown()
+    {
+        world.Dispose();
+    }
+
+    [Benchmark]
+    public void Run()
+    {
+        world.Execute<AddComponents, Component1, Component2, Component3, Component4, Component5>(query);
+    }
+
+    private readonly struct AddComponents
+        : IQuery5<Component1, Component2, Component3, Component4, Component5>
+    {
+        public void Execute(Entity e, ref Component1 c1, ref Component2 c2, ref Component3 c3, ref Component4 c4, ref Component5 c5)
+        {
+            c1.Value = c2.Value + c3.Value + c4.Value + c5.Value;
+        }
+    }
+}

--- a/src/Myriad/_BenchUtils.cs
+++ b/src/Myriad/_BenchUtils.cs
@@ -1,0 +1,36 @@
+using Myriad.ECS;
+using Myriad.ECS.Command;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+public static class _BenchUtils
+{
+    public static Entity[] CreateEntities(this World world, int count)
+    {
+        var buffer = new CommandBuffer(world);
+        for (var n = 0; n < count; n++)
+            buffer.Create();
+
+        using var resolver = buffer.Playback();
+        var result = new Entity[count];
+        for (var i = 0; i < resolver.Count; i++)
+            result[i] = resolver[i];
+
+        return result;
+    }
+
+    public static void AddComponents(this Entity[] entities, World world)
+    {
+        var buffer = new CommandBuffer(world);
+
+        foreach (var entity in entities)
+        {
+            buffer.Set(entity, new Component1());
+            buffer.Set(entity, new Component2());
+            buffer.Set(entity, new Component3());
+            buffer.Set(entity, new Component4());
+            buffer.Set(entity, new Component5());
+        }
+    }
+}

--- a/src/Myriad/_Components.cs
+++ b/src/Myriad/_Components.cs
@@ -1,0 +1,18 @@
+
+using Myriad.ECS;
+
+namespace Myriad;
+
+#pragma warning disable CS0649 // Field is never assigned to, and will always have its default value
+
+internal record struct Component1(int Value) : IComponent;
+
+internal record struct Component2(int Value) : IComponent;
+
+internal record struct Component3(int Value) : IComponent;
+
+internal record struct Component4(int Value) : IComponent;
+
+internal record struct Component5(int Value) : IComponent;
+
+internal record struct SearchableComponent(int Value) : IComponent;


### PR DESCRIPTION
Added basic support for `Myriad.ECS`.

There are a couple of issues here I want to raise:

Myriad doesn't support adding/removing components or creating/deleting entities without using a `CommandBuffer`. Right now I haven't implemented those benchmarks (especially since there's a separate category for `CommandBuffer` based operations). Do you think I should implement them, using a `CommandBuffer`?

Alternatively, we could expand the category of `CommandBuffer` operations to cover all these things - right now there's just one benchmark that does adding _and_ removing components with a buffer, which feels a bit weird. This could be expanded into:
 - Buffered add component to existing entity
 - Buffered remove component
 - Buffered create entity with N components
 - Buffered destroy entity

Another thing, this isn't an issue with Myriad specifically, is that the entity counts seem very small. For example the query benchmarks (`QueryT1`, `QueryT5`, `QueryFragmentedT1`) all operate over just 100 entities. Can I suggest parameterising this and running it at e.g. 100 and 10,000 entities? That way we can see better how the different options scale.