### PR TITLE
Fixed Myriad Query Benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ A sparse Set based ECS stores each component in its own sparse set which is has 
 | Friflo.Engine.ECS    |  ✅  |  ✅ ¹     |  ✅           |   ✅   |   ✅   | m    |  ✅   |
 | Leopotam.EcsLite     |  ✅  |           |                |         |        | m, n |       |
 | Morpeh               |  ✅  |           |  ✅            |        |        | m, n |        |
+| Myriad.ECS           |  ✅  |           |  ✅            |        |        | m    |  ✅    |
 | TinyEcs              |  ✅  |  ✅       |  ✅           |   ✅   |        | m, n |        |
 
 ¹ Ensures a cycle free entity hierarchy. See [CheckTreeCycles()](https://github.com/search?q=repo%3Afriflo%2FECS.CSharp.Benchmark-common-use-cases+CheckTreeCycles&type=code)

--- a/src/Myriad/GetSetComponentsT1.cs
+++ b/src/Myriad/GetSetComponentsT1.cs
@@ -1,0 +1,35 @@
+using BenchmarkDotNet.Attributes;
+using Myriad.ECS;
+using Myriad.ECS.Worlds;
+
+namespace Myriad;
+
+[BenchmarkCategory(Category.GetSetComponentsT1)]
+// ReSharper disable once InconsistentNaming
+public class GetSetComponentsT1_Myriad
+{
+    private World       world;
+    private Entity[]    entities;
+    
+    [GlobalSetup]
+    public void Setup()
+    {
+        world = new WorldBuilder().Build();
+
+        entities = world.CreateEntities(Constants.EntityCount);
+        entities.AddComponents(world);
+    }
+    
+    [GlobalCleanup]
+    public void Shutdown()
+    {
+        world.Dispose();
+    }
+    
+    [Benchmark]
+    public void Run()
+    {
+        foreach (var entity in entities)
+            entity.GetComponentRef<Component1>(world) = new Component1();
+    }
+}

--- a/src/Myriad/_BenchUtils.cs
+++ b/src/Myriad/_BenchUtils.cs
@@ -32,5 +32,7 @@ public static class _BenchUtils
             buffer.Set(entity, new Component4());
             buffer.Set(entity, new Component5());
         }
+
+        buffer.Playback().Dispose();
     }
 }

--- a/src/Myriad/_Components.cs
+++ b/src/Myriad/_Components.cs
@@ -14,5 +14,3 @@ internal record struct Component3(int Value) : IComponent;
 internal record struct Component4(int Value) : IComponent;
 
 internal record struct Component5(int Value) : IComponent;
-
-internal record struct SearchableComponent(int Value) : IComponent;


### PR DESCRIPTION
I noticed that in your latest run the Myriad.ECS query benchmarks are broken. This was due to a mistake on my part, when moving some of the code into `_BenchUtils` I managed to lose the line that actually executes the setup `CommandBuffer`! Sorry about that.

I've also implemented the `GetSetComponentsT1` benchmark for Myriad and have added it to the readme feature matrix.

## Summary
 - Fixed Myriad.ECS benchmarks for `QueryT1` and `QueryT5`
 - Added `GetSetComponentsT1` for Myriad.ECS
 - Updated readme to add Myriad.ECS to the feature matrix

## Approximate Results
These benchmarks were run on my PC (Ryzen 7950X) so are not directly comparable to the Mac Mini results, but it gives us an approximate idea where Myriad sits until the next time you run the benchmarks:
```
| Namespace         | Type                     | Mean      | Ratio | Allocated | 
|------------------ |------------------------- |----------:|------:|----------:|-
| Friflo.Engine.ECS | QueryFragmentedT1_Friflo |  29.64 ns |  1.00 |         - | 
| Myriad            | QueryFragmentedT1_Myriad |  80.59 ns |  2.72 |         - | 
| Arch              | QueryFragmentedT1_Arch   | 293.60 ns |  9.91 |         - | 
|                   |                          |           |       |           | 
| Friflo.Engine.ECS | QueryT1_Friflo           |  30.32 ns |  1.00 |         - | 
| Myriad            | QueryT1_Myriad           |  55.08 ns |  1.82 |         - | 
| Arch              | QueryT1_Arch             | 124.89 ns |  4.12 |         - | 
|                   |                          |           |       |           | 
| Myriad            | QueryT5_Myriad           |  71.49 ns |  0.82 |         - | 
| Friflo.Engine.ECS | QueryT5_Friflo           |  87.07 ns |  1.00 |         - | 
| Arch              | QueryT5_Arch             | 229.30 ns |  2.63 |         - | 
```