### PR TITLE
Using archs Query-API instead of InlineQuery. 

### DIFF
--- a/src/Arch/QueryComponents.cs
+++ b/src/Arch/QueryComponents.cs
@@ -10,6 +10,8 @@ public class QueryComponents_Arch : QueryComponents
     private World               world;
     private QueryDescription    query1Description;
     private QueryDescription    query5Description;
+    private Query               query1;
+    private Query               query5;
     private ForEach1            forEach1;
     private ForEach5            forEach5;
 
@@ -20,6 +22,8 @@ public class QueryComponents_Arch : QueryComponents
         world.CreateEntities(Entities).AddComponents();
         query1Description = new QueryDescription().WithAll<Component1>();
         query5Description = new QueryDescription().WithAll<Component1,Component2,Component3,Component4,Component5>();
+        query1 = world.Query(query1Description);
+        query5 = world.Query(query5Description);
         Check.AreEqual(Entities, world.CountEntities(query5Description));
     }
 
@@ -31,11 +35,32 @@ public class QueryComponents_Arch : QueryComponents
 
     protected override void Run1Component()
     {
-        world.InlineQuery<ForEach1, Component1>(query1Description, ref forEach1);
+        foreach (ref var chunk in query1.GetChunkIterator())
+        {
+            ref var first = ref chunk.GetFirst<Component1>();
+            foreach (var entity in chunk)
+            {
+                Unsafe.Add(ref first, entity).Value++;
+            }
+        }
     }
 
     protected override void Run5Components()
     {
-        world.InlineQuery<ForEach5, Component1,Component2,Component3,Component4,Component5>(query5Description, ref forEach5);
+        foreach (ref var chunk in query5.GetChunkIterator())
+        {
+            ref var first = ref chunk.GetFirst<Component1>();
+            ref var second = ref chunk.GetFirst<Component2>();
+            ref var third = ref chunk.GetFirst<Component3>();
+            ref var fourth = ref chunk.GetFirst<Component4>();
+            ref var fifth = ref chunk.GetFirst<Component5>();
+            foreach (var entity in chunk)
+            {
+                Unsafe.Add(ref first, entity).Value = Unsafe.Add(ref second, entity).Value +
+                                                      Unsafe.Add(ref third, entity).Value +
+                                                      Unsafe.Add(ref fourth, entity).Value +
+                                                      Unsafe.Add(ref fifth, entity).Value;
+            }
+        }
     }
 }

--- a/src/ECS.Benchmark.csproj
+++ b/src/ECS.Benchmark.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Arch" Version="1.3.0-alpha" />
+      <PackageReference Include="Arch" Version="1.3.1-alpha" />
       <PackageReference Include="Arch.Relationships" Version="1.0.1" />
       <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
       <PackageReference Include="DefaultEcs" Version="0.18.0-beta01" />
@@ -44,6 +44,7 @@
         <AllowUnsafeBlocks>false</AllowUnsafeBlocks>
         <DefineConstants>TRACE</DefineConstants>
         <OutputPath>..\bin\Debug\</OutputPath>
+        <Optimize>true</Optimize>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">

--- a/src/ECS.Benchmark.csproj
+++ b/src/ECS.Benchmark.csproj
@@ -10,7 +10,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="Arch" Version="1.3.1-alpha" />
+      <PackageReference Include="Arch" Version="1.3.0-alpha" />
       <PackageReference Include="Arch.Relationships" Version="1.0.1" />
       <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
       <PackageReference Include="DefaultEcs" Version="0.18.0-beta01" />


### PR DESCRIPTION
Another small PR. Ignore the up and downgrade of archs version, there was an unexpected bug that needs to be fixed first. 
Instead of the Unsafe-Syntax we could use `chunk.GetSpan<T>` instead if that's more appropriate. 