### PR TITLE
Update Myriad.ECS v36.6

### DIFF
--- a/src/ECS.Benchmark.csproj
+++ b/src/ECS.Benchmark.csproj
@@ -18,7 +18,7 @@
       <PackageReference Include="fennecs" Version="0.5.10-beta" />
       <PackageReference Include="Friflo.Engine.ECS" Version="3.0.0-preview.13" />
       <PackageReference Include="Friflo.Engine.ECS.Boost" Version="3.0.0-preview.13" />
-      <PackageReference Include="Myriad.ECS" Version="28.0.0" />
+      <PackageReference Include="Myriad.ECS" Version="36.6.0" />
       <PackageReference Include="Scellecs.Morpeh" Version="2023.1.0" />
       <PackageReference Include="TinyEcs.Main" Version="1.4.0" />
       <PackageReference Include="Leopotam.EcsLite" Version="1.0.1" />

--- a/src/Myriad/GetSetComponents.cs
+++ b/src/Myriad/GetSetComponents.cs
@@ -33,12 +33,16 @@ public class GetSetComponents_Myriad : GetSetComponents
 
     protected override void Run5Components()
     {
-        foreach (var entity in entities) {
-            entity.GetComponentRef<Component1>() = new Component1();
-            entity.GetComponentRef<Component2>() = new Component2();
-            entity.GetComponentRef<Component3>() = new Component3();
-            entity.GetComponentRef<Component4>() = new Component4();
-            entity.GetComponentRef<Component5>() = new Component5();
+        foreach (var entity in entities)
+        {
+            // Get references to all 5 components in one pass
+            var (_, c1, c2, c3, c4, c5) = entity.GetComponentRef<Component1, Component2, Component3, Component4, Component5>();
+
+            c1.Ref = new Component1();
+            c2.Ref = new Component2();
+            c3.Ref = new Component3();
+            c4.Ref = new Component4();
+            c5.Ref = new Component5();
         }
     }
 }


### PR DESCRIPTION
 - Update Myriad.ECS to v36.6
 - Using new reftuple to get all 5 components at once in `GetSetComponents` benchmark