### PR TITLE
Updated to Myriad.ECS v42.0.1

### DIFF
--- a/src/ECS.Benchmark.csproj
+++ b/src/ECS.Benchmark.csproj
@@ -19,7 +19,7 @@
       <PackageReference Include="Frent" Version="0.5.2-beta" />
       <PackageReference Include="Friflo.Engine.ECS" Version="3.0.0-preview.13" />
       <PackageReference Include="Friflo.Engine.ECS.Boost" Version="3.0.0-preview.13" />
-      <PackageReference Include="Myriad.ECS" Version="36.6.0" />
+      <PackageReference Include="Myriad.ECS" Version="42.0.1" />
       <PackageReference Include="Scellecs.Morpeh" Version="2023.1.0" />
       <PackageReference Include="TinyEcs.Main" Version="1.4.0" />
       <PackageReference Include="Leopotam.EcsLite" Version="1.0.1" />

--- a/src/Myriad/CreateEntity.cs
+++ b/src/Myriad/CreateEntity.cs
@@ -1,5 +1,6 @@
 using BenchmarkDotNet.Attributes;
 using Myriad.ECS.Command;
+using Myriad.ECS.Queries;
 using Myriad.ECS.Worlds;
 
 namespace Myriad;
@@ -10,15 +11,27 @@ public class CreateEntity_Myriad : CreateEntity
     private World           world;
     private CommandBuffer   buffer;
 
-    [IterationSetup]
-    public void Setup()
+    [GlobalSetup]
+    public void GlobalSetup()
     {
         world = new WorldBuilder().Build();
         buffer = new CommandBuffer(world);
     }
 
+    [IterationSetup]
+    public void Setup()
+    {
+    }
+
     [IterationCleanup]
     public void Shutdown()
+    {
+        // Delete everything
+        buffer.Delete(new QueryBuilder().Build(world));
+    }
+
+    [GlobalCleanup]
+    public void GlobalCleanup()
     {
         world.Dispose();
     }

--- a/src/Myriad/DeleteEntity.cs
+++ b/src/Myriad/DeleteEntity.cs
@@ -1,4 +1,4 @@
-﻿using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Attributes;
 using Myriad.ECS;
 using Myriad.ECS.Command;
 using Myriad.ECS.Worlds;
@@ -12,16 +12,21 @@ public class DeleteEntity_Myriad : DeleteEntity
     private Entity[]    entities;
     private CommandBuffer cmd;
 
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        world = new WorldBuilder().Build();
+        cmd   = new CommandBuffer(world);
+    }
+
     [IterationSetup]
     public void Setup()
     {
-        world       = new WorldBuilder().Build();
-        entities    = world.CreateEntities(Entities);
+        entities = world.CreateEntities(Entities);
         entities.AddComponents(world);
-        cmd         = new CommandBuffer(world);
     }
 
-    [IterationCleanup]
+    [GlobalCleanup]
     public void Shutdown()
     {
         world.Dispose();

--- a/src/Myriad/QueryComponents.cs
+++ b/src/Myriad/QueryComponents.cs
@@ -34,7 +34,7 @@ public class QueryComponents_Myriad : QueryComponents
 
     protected override void Run1Component()
     {
-        world.Execute<IncrementComponent1, Component1>(query1);
+        world.ExecuteChunk<IncrementComponent1, Component1>(query1);
     }
 
     protected override void Run5Components()
@@ -44,11 +44,14 @@ public class QueryComponents_Myriad : QueryComponents
 }
 
 internal readonly struct IncrementComponent1
-    : IQuery<Component1>
+    : IChunkQuery<Component1>
 {
-    public void Execute(Entity e, ref Component1 t0)
+    public void Execute(ChunkHandle chunk, Span<Component1> t0)
     {
-        t0.Value++;
+        foreach (ref var item in t0)
+        {
+            item.Value++;
+        }
     }
 }
 

--- a/src/Myriad/QueryFragmented.cs
+++ b/src/Myriad/QueryFragmented.cs
@@ -1,5 +1,4 @@
 using BenchmarkDotNet.Attributes;
-using Myriad.ECS;
 using Myriad.ECS.Command;
 using Myriad.ECS.Queries;
 using Myriad.ECS.Worlds;
@@ -47,15 +46,18 @@ public class QueryFragmented_Myriad : QueryFragmented
     [Benchmark]
     public override void Run()
     {
-        world.Execute<IncrementComponent1, Component1>(query);
+        world.ExecuteChunk<IncrementComponent1, Component1>(query);
     }
 
     private readonly struct IncrementComponent1
-        : IQuery<Component1>
+        : IChunkQuery<Component1>
     {
-        public void Execute(Entity e, ref Component1 t0)
+        public void Execute(ChunkHandle chunk, Span<Component1> t0)
         {
-            t0.Value++;
+            foreach (ref var item in t0)
+            {
+                item.Value++;
+            }
         }
     }
 }


### PR DESCRIPTION
Updated to the latest version of Myriad.ECS

Also tweaked some benchmarks at the same time:

Moved world/buffer creation to `GlobalSetup`. Myriad.ECS caches things internally, so doing creation in `IterationSetup` was forcing cold caches on every run. This was slower and made the allocation stats look terrible (due to allocating those caches as part of the run).

Switched to chunk queries, to line up more closely with how the equivalent Friflo benchmarks are implemented (a loop over chunks)